### PR TITLE
Store old game ids on game suppression.

### DIFF
--- a/wegas-app/src/main/webapp/wegas-admin/js/controller/game.js
+++ b/wegas-app/src/main/webapp/wegas-admin/js/controller/game.js
@@ -74,6 +74,9 @@ define(["ember"], function(Ember) {
         isDelete: function() {
             return this.get("model").get("gameStatus") === "DELETE";
         }.property(),
+        isSuppressed: function() {
+            return this.get("model").get("gameStatus") === "SUPPRESSED";
+        }.property(),
         gameLink: function(key, value) {
             return "host.html?gameId=" + this.get("model").get("gameId");
         }.property("gameId"),

--- a/wegas-app/src/main/webapp/wegas-admin/js/templates/games.hbs
+++ b/wegas-app/src/main/webapp/wegas-admin/js/templates/games.hbs
@@ -37,7 +37,7 @@
             {{else}}
                 <td {{action "editComment" on="click"}}>{{textarea class="form-control" value=game.comments focus-out="acceptComment" rows="1" disabled="true"}}</td>
             {{/if}}
-            <td class="centeredText"><a target="_blank" {{bind-attr href="game.gameLink"}}>View</a></td>
+            <td class="centeredText">{{#unless game.isSuppressed}}<a target="_blank" {{bind-attr href="game.gameLink"}}>View</a>{{/unless}}</td>
             <td class="centeredText">{{#if game.isDelete}}
                 <a class="mouse-pointer" target="_blank" {{action "forceDeletion" on="click"}}>Delete</a>
             {{/if}}</td>

--- a/wegas-core/src/main/java/com/wegas/admin/persistence/GameAdmin.java
+++ b/wegas-core/src/main/java/com/wegas/admin/persistence/GameAdmin.java
@@ -67,6 +67,8 @@ public class GameAdmin extends AbstractEntity {
     @Lob
     private String prevPlayers;
 
+    private Long prevGameId;
+
     @Lob
     private String prevTeams;
 
@@ -125,7 +127,7 @@ public class GameAdmin extends AbstractEntity {
         if (this.getGame() != null) {
             return this.getGame().getId();
         }
-        return null;
+        return this.prevGameId;
     }
 
     public Date getCreatedTime() {
@@ -155,6 +157,7 @@ public class GameAdmin extends AbstractEntity {
             this.prevTeamCount = this.getTeamCount();
             this.prevPlayers = this.getPlayers().toString();
             this.prevTeams = this.getTeams().toString();
+            this.prevGameId = this.getGame().getId();
         }
     }
 

--- a/wegas-core/src/main/resources/dbchangelogs/1503326362.xml
+++ b/wegas-core/src/main/resources/dbchangelogs/1503326362.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="cigit" id="1503326362">
+        <addColumn tableName="gameadmin">
+            <column name="prevgameid" type="int8"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
admin page: Remove link to suppressed games.

This allows to make a link with stats' gameId and thus recover some informations about given game.