### PR TITLE
Don't fetch instance on Container expansion

### DIFF
--- a/wegas-app/src/main/webapp/wegas-editor/js/widget/wegas-editor-variabletreeview.js
+++ b/wegas-app/src/main/webapp/wegas-editor/js/widget/wegas-editor-variabletreeview.js
@@ -605,17 +605,14 @@ YUI.add('wegas-editor-variabletreeview', function(Y) {
             var node = e.node,
                 entity = node.get("data.entity"),
                 id = entity.get(ID);
-            if (entity instanceof Wegas.persistence.ListDescriptor) {
                 if (node.size() > 0) {
                     return;
                 }
-                node.add(this.get("host").genTreeViewElements(entity.get("items")));
-            } else if (entity instanceof Wegas.persistence.VariableDescriptor &&
-                !(Wegas.persistence.ChoiceDescriptor && entity instanceof Wegas.persistence.ChoiceDescriptor)) { // @hack
-
-                if (node.size() > 1) { /* @fixme @hack What if there is only 1 player in the game ? */
-                    return;
-                }
+            if (typeof entity.isAugmentedBy === 'function'
+                && entity.isAugmentedBy(Wegas.persistence.VariableContainer)) {
+                node.add(this.get('host').genTreeViewElements(entity.get('items')));
+            } else if (entity instanceof Wegas.persistence.VariableDescriptor 
+                    && !(Wegas.persistence.ChoiceDescriptor && entity instanceof Wegas.persistence.ChoiceDescriptor)) {
                 node.destroyAll();
                 node.set("loading", true);
                 Wegas.Facade.Instance.sendRequest({


### PR DESCRIPTION
Simply expand Variable _implementing_ VariableContainer (previously only ListDescriptor had this behavior)

Remove hack. instance are now loaded correctly