### PR TITLE
Modifying shiro configuration to allow non ascii char in URLs

### DIFF
--- a/wegas-app/src/main/webapp/WEB-INF/shiro.ini
+++ b/wegas-app/src/main/webapp/WEB-INF/shiro.ini
@@ -11,6 +11,18 @@
 sessionManager = org.apache.shiro.web.session.mgt.DefaultWebSessionManager
 sessionManager.globalSessionTimeout = 3600000
 
+# For shiro >= 1.7.0
+# Explicit url rewriting must be set in order to work with special chars (File management needs that)
+sessionManager.sessionIdUrlRewritingEnabled = true
+invalidRequest = org.apache.shiro.web.filter.InvalidRequestFilter
+invalidRequest.blockNonAscii = false
+
+#RequestFilter unmodified default values
+#invalidRequest.blockBackslash = true
+#invalidRequest.blockSemicolon = true
+
+
+
 #activeSessionsCache = com.wegas.core.security.util.ShiroCacheImplementation
 #sessionDAO = org.apache.shiro.session.mgt.eis.EnterpriseCacheSessionDAO
 #sessionDAO.activeSessionsCache = $activeSessionsCache


### PR DESCRIPTION
Étonnamment nous n'avons pas encore reçu de mails mais depuis l'update de shiro il était impossible d'upload ou de lire des fichiers avec des caractères spéciaux.
A partir de la version 1.7 shiro ne traduit plus les URL automatiquement : https://issues.apache.org/jira/browse/SHIRO-795?jql=project%20%3D%20SHIRO%20AND%20fixVersion%20%3D%201.7.0