### PR TITLE
fixes #1730

### DIFF
--- a/wegas-app/src/main/webapp/wegas-react-form/src/Views/html.js
+++ b/wegas-app/src/main/webapp/wegas-react-form/src/Views/html.js
@@ -131,6 +131,7 @@ function getTinyConfig(fixedToolbar) {
         //     editor.on('focus', () => tbs.forEach(e => { e.style.maxHeight = '90px'; }));
         //     editor.on('blur', () => tbs.forEach(e => { e.style.maxHeight = 0; }));
         // }
+        entity_encoding: 'raw'
     };
 
     const extraButtons = Wegas.Config.TinyExtraButtons;


### PR DESCRIPTION
J'ai hésité entre transformer le retour de sanitize en encodant en html
```
 function escapeHTMLEncode(str) {
  var div = document.createElement(‘div’);
  var text = document.createTextNode(str);
  div.appendChild(text);
  return div.innerHTML;
 }
```
la le problème c'est que le sanitizer va automatiquement tout encoder donc le problème va se répercuter plus loin.

Du coup j'ai simplement dit a tinyMCE de ne pas encoder les char spéciaux.

T'es ok avec ça @maxencelaurent  ?