### PR TITLE
Remove numberInput debounce

### DIFF
--- a/wegas-app/src/main/node/wegas-react/src/Components/Inputs/Number/NumberInput.tsx
+++ b/wegas-app/src/main/node/wegas-react/src/Components/Inputs/Number/NumberInput.tsx
@@ -13,34 +13,21 @@ interface NumberInputProps extends InputProps<number> {
 
 export function NumberInput(props: NumberInputProps) {
   const { value, placeholder } = props;
-  const valueRef = React.useRef(String(value));
-  const [inputValue, setInputValue] = React.useState<string>('');
-
-  const onBlur = () => {
-    setInputValue(String(value));
-  };
-
-  React.useEffect(() => {
-    Number(valueRef.current) === value
-      ? setInputValue(valueRef.current)
-      : setInputValue(String(value));
-  }, [value]);
 
   return (
     <SimpleInput
       {...omit(props, 'onChange')}
-      value={inputValue}
+      value={value}
       className={numberInputStyle}
       onChange={v => {
         const vN = Number(v);
-        valueRef.current = String(v);
+        // valueRef.current = String(v);
         if (!isNaN(vN)) {
           props.onChange && props.onChange(vN);
         }
       }}
       inputType='number'
       placeholder={placeholder}
-      onBlur={onBlur}
     />
   );
 }

--- a/wegas-app/src/main/node/wegas-react/src/Components/Inputs/Number/NumberInput.tsx
+++ b/wegas-app/src/main/node/wegas-react/src/Components/Inputs/Number/NumberInput.tsx
@@ -21,7 +21,6 @@ export function NumberInput(props: NumberInputProps) {
       className={numberInputStyle}
       onChange={v => {
         const vN = Number(v);
-        // valueRef.current = String(v);
         if (!isNaN(vN)) {
           props.onChange && props.onChange(vN);
         }

--- a/wegas-app/src/main/node/wegas-react/src/Components/Inputs/SimpleInput.tsx
+++ b/wegas-app/src/main/node/wegas-react/src/Components/Inputs/SimpleInput.tsx
@@ -119,8 +119,7 @@ export function SimpleInput({
   inputType = 'text',
   debouncingTime = 400,
 }: SimpleInputProps) {
-  const inputRef = React.useRef<HTMLInputElement>(null);
-  const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
+  const elementRef = React.useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
 
   React.useEffect(() => {
     if (autoFocus) {
@@ -146,7 +145,7 @@ export function SimpleInput({
   if (typeof rows === 'number') {
     return (
       <textarea
-        ref={textAreaRef}
+        ref={e => elementRef.current = e}
         className={inputStyle + classNameOrEmpty(className)}
         style={{ ...(fullWidth ? { width: '100%' } : {}), ...style }}
         id={id}
@@ -163,7 +162,7 @@ export function SimpleInput({
   }
   return (
     <input
-      ref={inputRef}
+      ref={e => elementRef.current = e}
       type={inputType}
       className={inputStyle + classNameOrEmpty(className)}
       style={{ ...(fullWidth ? { width: '100%' } : {}), ...style }}

--- a/wegas-app/src/main/node/wegas-react/src/Components/Inputs/SimpleInput.tsx
+++ b/wegas-app/src/main/node/wegas-react/src/Components/Inputs/SimpleInput.tsx
@@ -55,10 +55,6 @@ export interface InputProps<T> extends ClassStyleId, DisabledReadonly {
    */
   onChange?: (value: T) => void;
   /**
-   * onChange - return the value set by the component
-   */
-  onBlur?: () => void;
-  /**
    * label - the current label of the input
    */
   label?: React.ReactNode;
@@ -109,7 +105,7 @@ export interface SimpleInputProps extends InputProps<string | number> {
 export function SimpleInput({
   value,
   onChange,
-  onBlur,
+
   rows,
   disabled,
   readOnly,
@@ -134,15 +130,17 @@ export function SimpleInput({
     }
   }, [autoFocus]);
 
-  const { currentValue, debouncedOnChange, flush } = useDebouncedOnChange(
+  const { currentValue, debouncedOnChange, } = useDebouncedOnChange(
     value,
     onChange,
     debouncingTime,
   );
 
   const onInputChange = React.useCallback(
-    (ev: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-      debouncedOnChange(ev.currentTarget.value),
+    (ev: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      debouncedOnChange(ev.currentTarget.value);
+    }
+      ,
     [debouncedOnChange],
   );
 
@@ -157,10 +155,6 @@ export function SimpleInput({
         rows={rows}
         onChange={onInputChange}
         placeholder={placeholder}
-        onBlur={() => {
-          onBlur && onBlur();
-          flush();
-        }}
         disabled={disabled}
         readOnly={readOnly}
         autoComplete={autoComplete ? 'on' : 'off'}
@@ -178,10 +172,10 @@ export function SimpleInput({
       value={undefToEmpty(currentValue)}
       onChange={onInputChange}
       placeholder={placeholder}
-      onBlur={() => {
-        onBlur && onBlur();
-        flush();
-      }}
+      // onBlur={() => {
+      //   onBlur && onBlur();
+      //   flush();
+      // }}
       disabled={disabled}
       readOnly={readOnly}
       autoComplete={autoComplete ? 'on' : 'off'}

--- a/wegas-app/src/main/node/wegas-react/src/Components/Inputs/SimpleInput.tsx
+++ b/wegas-app/src/main/node/wegas-react/src/Components/Inputs/SimpleInput.tsx
@@ -105,7 +105,6 @@ export interface SimpleInputProps extends InputProps<string | number> {
 export function SimpleInput({
   value,
   onChange,
-
   rows,
   disabled,
   readOnly,

--- a/wegas-app/src/main/node/wegas-react/src/Components/Inputs/SimpleInput.tsx
+++ b/wegas-app/src/main/node/wegas-react/src/Components/Inputs/SimpleInput.tsx
@@ -121,12 +121,12 @@ export function SimpleInput({
   debouncingTime = 400,
 }: SimpleInputProps) {
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const textAeraRef = React.useRef<HTMLTextAreaElement>(null);
+  const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
 
   React.useEffect(() => {
     if (autoFocus) {
       inputRef.current?.focus();
-      textAeraRef.current?.focus();
+      textAreaRef.current?.focus();
     }
   }, [autoFocus]);
 
@@ -147,7 +147,7 @@ export function SimpleInput({
   if (typeof rows === 'number') {
     return (
       <textarea
-        ref={textAeraRef}
+        ref={textAreaRef}
         className={inputStyle + classNameOrEmpty(className)}
         style={{ ...(fullWidth ? { width: '100%' } : {}), ...style }}
         id={id}
@@ -172,10 +172,6 @@ export function SimpleInput({
       value={undefToEmpty(currentValue)}
       onChange={onInputChange}
       placeholder={placeholder}
-      // onBlur={() => {
-      //   onBlur && onBlur();
-      //   flush();
-      // }}
       disabled={disabled}
       readOnly={readOnly}
       autoComplete={autoComplete ? 'on' : 'off'}

--- a/wegas-app/src/main/node/wegas-react/src/Components/PageComponents/Inputs/Number.component.tsx
+++ b/wegas-app/src/main/node/wegas-react/src/Components/PageComponents/Inputs/Number.component.tsx
@@ -1,4 +1,3 @@
-import { debounce } from 'lodash-es';
 import React from 'react';
 import { SNumberDescriptor } from 'wegas-ts-api';
 import { Actions } from '../../../data';
@@ -79,12 +78,6 @@ function PlayerNumberInput({
     [handleOnChange, number],
   );
 
-  const debounceOnChange = React.useMemo(() => {
-    return debounce((value: number) => {
-      onChange(value);
-    }, 300);
-  }, [onChange]);
-
   return number == null ? (
     <UncompleteCompMessage
       message={somethingIsUndefined('Number')}
@@ -99,7 +92,7 @@ function PlayerNumberInput({
       id={id}
       readOnly={readOnly}
       disabled={disabled || locked}
-      onChange={debounceOnChange}
+      onChange={onChange}
       placeholder={placeholderText}
     />
   );


### PR DESCRIPTION
Removed:
- NumberInput & SimpleInput onBlur
- NumberInput intermediary ref and state (superfluous)
- Number.component 300ms debounce (needed for slider but not input)

We could also add a "integer" or "step" notion to the Number.component similar to NumberSlider.component but should be identical behaviour for both