### PR TITLE
Label associated to a 0 value in a select component is displayed correctly

### DIFF
--- a/wegas-app/src/main/node/wegas-react/src/Components/PageComponents/Inputs/Select.component.tsx
+++ b/wegas-app/src/main/node/wegas-react/src/Components/PageComponents/Inputs/Select.component.tsx
@@ -63,10 +63,12 @@ function PlayerSelectInput({
   );
 
   const value = useStore(
-    () =>
-      (descriptor != null && typeof descriptor === 'object'
+    () => {
+      const v = (descriptor != null && typeof descriptor === 'object'
         ? descriptor.getValue(Player.self())
-        : descriptor) || '',
+        : descriptor);
+      return v == undefined ? '' : v;
+    }
   );
 
   const { lang } = React.useContext(languagesCTX);


### PR DESCRIPTION
Small visual fix

A choice pair in a select with value 0 
`{label :'A', value: 0}`

was not displaying A when selected.
