### PR TITLE
WEG-174 Advanced shortcut now works with Safari + Chrome

### DIFF
--- a/wegas-app/src/main/node/wegas-react/src/Components/Contexts/FeaturesProvider.tsx
+++ b/wegas-app/src/main/node/wegas-react/src/Components/Contexts/FeaturesProvider.tsx
@@ -59,7 +59,8 @@ function FeaturesContext({
 
   const listener = React.useCallback(
     (event: KeyboardEvent) => {
-      if (event.ctrlKey && event.code === 'Backquote') {
+      if (event.ctrlKey &&
+        (event.code === 'IntlBackslash' || event.code === 'Backquote')) { // The very left key on the second line from top (usually §). On August 2025, for Safari and Chrome, it is IntlBackslash. For FireFox, it is Backquote
         toggleFeature(event.altKey ? 'INTERNAL' : 'ADVANCED');
       }
       if (event.ctrlKey && event.code === 'KeyS') {


### PR DESCRIPTION
To toggle Advanced mode, we use Ctrl + The very left key on the second line from top (usually §)
. On August 2025, for Safari and Chrome, it is IntlBackslash. For FireFox, it is Backquote