### PR TITLE
Activate PMD static analysis and wire into CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -76,6 +76,11 @@ jobs:
     - name: Build with Maven
       run: mvn -B -P release-profile package --file pom.xml
 
+    - name: Static analysis (PMD)
+      run: |
+        mvn -B -pl build-tools install -DskipTests --file pom.xml
+        mvn -B pmd:check --file pom.xml
+
     - name: export cypress failures to filebin.net
       if: ${{ failure() }}
       shell: bash

--- a/pom.xml
+++ b/pom.xml
@@ -801,7 +801,7 @@
                         <printFailingErrors>true</printFailingErrors>
                         <failurePriority>2</failurePriority>
                         <rulesets>
-                            <rulset>wegas/pmd/default-ruleset.xml</rulset>
+                            <ruleset>wegas/pmd/default-ruleset.xml</ruleset>
                         </rulesets>
                         <excludeRoots>
                             <excludeRoot>target/generated-sources/plugin</excludeRoot>

--- a/wegas-core/src/main/java/com/wegas/log/xapi/ActivityDefinition.java
+++ b/wegas-core/src/main/java/com/wegas/log/xapi/ActivityDefinition.java
@@ -1,12 +1,10 @@
 package com.wegas.log.xapi;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map.Entry;
 
 /*
  * Copied from gov.adlnet.xapi.model when removing learning locker + xapi logging.
@@ -36,23 +34,6 @@ public class ActivityDefinition {
     public ActivityDefinition(HashMap<String, String> name, HashMap<String, String> description) {
         this.name = name;
         this.description = description;
-    }
-
-    private JsonElement serializeMap(HashMap<String, String> map) {
-        JsonObject obj = new JsonObject();
-        for (Entry<String, String> item : map.entrySet()) {
-            obj.addProperty(item.getKey(), item.getValue());
-        }
-        return obj;
-    }
-
-    private JsonElement serializeInteractionComponents(
-            ArrayList<InteractionComponent> components) {
-        JsonArray array = new JsonArray();
-        for (InteractionComponent comp : components) {
-            array.add(comp.serialize());
-        }
-        return array;
     }
 
     public JsonElement serialize() {

--- a/wegas-core/src/main/java/com/wegas/log/xapi/Attachment.java
+++ b/wegas-core/src/main/java/com/wegas/log/xapi/Attachment.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
  */
 
 public class Attachment {
-    private final static char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
     private URI usageType;                            //required
     private HashMap<String, String> display;        //required
     private HashMap<String, String> description;    //optional
@@ -22,10 +21,6 @@ public class Attachment {
     private int length;                                //required
     private String sha2;                            //required
     private URI fileUrl;                            //optional
-
-    private static String bytesToHex(byte[] bytes) {
-        return "";
-    }
 
     public static String generateSha2(byte[] bytes) throws NoSuchAlgorithmException {
         return "";
@@ -77,10 +72,6 @@ public class Attachment {
 
     public void setFileUrl(URI fileUrl) {
         this.fileUrl = fileUrl;
-    }
-
-    private JsonElement serializeHash(HashMap<String, String> map) {
-        return new JsonObject();
     }
 
     public JsonElement serialize() {

--- a/wegas-core/src/main/java/com/wegas/log/xapi/InteractionComponent.java
+++ b/wegas-core/src/main/java/com/wegas/log/xapi/InteractionComponent.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.util.HashMap;
-import java.util.Map.Entry;
 
 /*
  * Copied from gov.adlnet.xapi.model when removing learning locker + xapi logging.
@@ -29,14 +28,6 @@ public class InteractionComponent {
 
     public void setDescription(HashMap<String, String> description) {
         this.description = description;
-    }
-
-    private JsonElement serializeMap(HashMap<String, String> map) {
-        JsonObject obj = new JsonObject();
-        for (Entry<String, String> item : map.entrySet()) {
-            obj.addProperty(item.getKey(), item.getValue());
-        }
-        return obj;
     }
 
     public JsonElement serialize() {


### PR DESCRIPTION
Activates the PMD ruleset that was silently disabled and enforces it in CI.

- Fix `pom.xml` typo `<rulset>` → `<ruleset>` so `default-ruleset.xml` is applied.
- Add a PMD step to the CI workflow (installs build-tools, runs `pmd:check`).
- Remove genuinely-dead private members in the legacy `log.xapi` package.

Build-safe: all 331 reactor violations are priority 3–4, and `failurePriority=2` only fails on priority 1–2, so `pmd:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)