### PR TITLE
WEG-299 Implement OTel Java Agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ wegas-runtime/src/main/docker/wegas/Wegas.war
 wegas-runtime/src/main/docker/wegas/run
 wegas-runtime/src/main/docker/wegas/as_prebootcmd
 wegas-runtime/src/main/docker/wegas/payara-micro.current.jar
+wegas-runtime/src/main/docker/wegas/opentelemetry-javaagent.jar
 
 # Compiled source #
 ###################

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
         <jakartaPac4jVersion>8.0.1</jakartaPac4jVersion>
 
         <payara.version>6.2024.8</payara.version>
+        <otel.agent.version>2.30.0</otel.agent.version>
 
         <junit.version>4.13.1</junit.version>
         <arquillian.version>1.7.1.Final</arquillian.version>

--- a/wegas-runtime/.gitignore
+++ b/wegas-runtime/.gitignore
@@ -1,3 +1,4 @@
 src/main/resources/wegas-override.properties
 src/main/resources/default_wegas.properties.orig
 hs_err_pid*.log
+logging.properties

--- a/wegas-runtime/OTEL.md
+++ b/wegas-runtime/OTEL.md
@@ -1,0 +1,215 @@
+# OpenTelemetry Java Agent — Configuration Guide
+
+This document explains how the OpenTelemetry (OTel) Java agent is configured for Wegas:
+the variables involved, how the two configuration formats (`otel.*` vs `OTEL_*`) relate,
+the precedence rules, and — importantly — why **`OTEL_ENABLED` must live in the
+environment / command line** for the agent to be attached at all.
+
+The agent is attached in the launch script [`wegas-runtime/run`](run) via the JVM
+`-javaagent:` flag, and it auto-instruments HTTP, JAX-RS, JDBC/Postgres, etc. and exports
+telemetry over OTLP to a collector/backend of your choice (e.g. a self-hosted SigNoz).
+
+---
+
+## 1. Two kinds of variables — don't confuse them
+
+There are **two distinct categories** of variables at play.
+
+### a) Script-level variables (read by `run`, *not* by the agent)
+
+These are plain shell variables that the `run` script reads to decide **how to launch the
+JVM**. The OTel agent never sees them.
+
+| Variable         | Default                             | Purpose                                                                 |
+|------------------|-------------------------------------|-------------------------------------------------------------------------|
+| `OTEL_ENABLED`   | `false`                             | Main on/off switch. When `true`, `run` adds `-javaagent:` to the JVM. |
+| `OTEL_AGENT_JAR` | `target/opentelemetry-javaagent.jar`| Path to the agent jar (Docker image sets `/opt/wegas/...`).             |
+| `OTEL_CONFIG_FILE` | `otel.properties`                 | Optional agent config file passed via `-Dotel.javaagent.configuration-file`. |
+
+> ⚠️ **These cannot be set through `default_wegas.properties` / `wegas-override.properties`.**
+> Those Wegas files are handed to Payara via `--systemproperties` and are only applied
+> *after* the JVM has started and Payara boots — far too late, and with the wrong key form.
+> Script-level variables must be real environment variables or passed on the command line.
+
+### b) OpenTelemetry agent variables (read by the agent itself)
+
+These configure the agent's behaviour (where to export, what to export, service name, …).
+They come in two interchangeable **formats** (see §2) and can be supplied via environment
+variables, `-D` system properties, or the agent config file (see §4).
+
+| Dotted form (`otel.*`)          | Env-var form (`OTEL_*`)          | Meaning                                                                 |
+|---------------------------------|----------------------------------|-------------------------------------------------------------------------|
+| `otel.service.name`             | `OTEL_SERVICE_NAME`              | Logical service name shown in the backend (e.g. `wegas`).               |
+| `otel.exporter.otlp.endpoint`   | `OTEL_EXPORTER_OTLP_ENDPOINT`    | OTLP collector URL (e.g. `http://localhost:4318`).                      |
+| `otel.exporter.otlp.protocol`   | `OTEL_EXPORTER_OTLP_PROTOCOL`    | `http/protobuf` (port 4318) or `grpc` (port 4317).                      |
+| `otel.traces.exporter`          | `OTEL_TRACES_EXPORTER`           | `otlp`, `logging`, `none`, or a comma list (e.g. `otlp,logging`).       |
+| `otel.metrics.exporter`         | `OTEL_METRICS_EXPORTER`          | `otlp`, `logging`, `none`.                                              |
+| `otel.logs.exporter`            | `OTEL_LOGS_EXPORTER`             | `otlp`, `logging`, `none`.                                              |
+| `otel.resource.attributes`      | `OTEL_RESOURCE_ATTRIBUTES`       | Extra resource tags, e.g. `deployment.environment=dev,service.version=4.1`. |
+| `otel.traces.sampler`           | `OTEL_TRACES_SAMPLER`            | e.g. `parentbased_always_on` (default) or `parentbased_traceidratio`.   |
+| `otel.traces.sampler.arg`       | `OTEL_TRACES_SAMPLER_ARG`        | Sampler argument, e.g. `0.1` for 10% sampling.                          |
+| `otel.exporter.otlp.headers`    | `OTEL_EXPORTER_OTLP_HEADERS`     | Auth headers (e.g. ingestion key). **Secret — env/secret-manager only.** |
+| `otel.javaagent.configuration-file` | `OTEL_JAVAAGENT_CONFIGURATION_FILE` | Path to an agent properties file (see §4).                       |
+| `otel.sdk.disabled`             | `OTEL_SDK_DISABLED`              | Alternative kill-switch (see §5).                                       |
+
+---
+
+## 2. Dotted format ↔ environment-variable format
+
+Every OTel setting has two equivalent names. To convert the **dotted** system-property
+form to the **environment-variable** form:
+
+1. Convert to **UPPERCASE**.
+2. Replace every `.` **and** `-` with `_`.
+
+```
+otel.exporter.otlp.endpoint        ->  OTEL_EXPORTER_OTLP_ENDPOINT
+otel.service.name                  ->  OTEL_SERVICE_NAME
+otel.traces.sampler.arg            ->  OTEL_TRACES_SAMPLER_ARG
+otel.javaagent.configuration-file  ->  OTEL_JAVAAGENT_CONFIGURATION_FILE   (hyphen -> _)
+```
+
+They are fully interchangeable — pick whichever fits the delivery mechanism:
+
+- On the **command line / JVM args**: dotted form as a `-D` flag → `-Dotel.service.name=wegas`
+- As an **environment variable**: `OTEL_SERVICE_NAME=wegas`
+- In an **agent config file**: dotted form → `otel.service.name=wegas`
+
+---
+
+## 3. Precedence
+
+From highest to lowest priority:
+
+```
+1. System properties   (-Dotel.exporter.otlp.endpoint=...)   ← wins
+2. Environment variables (OTEL_EXPORTER_OTLP_ENDPOINT=...)
+3. Agent config file    (otel.properties via otel.javaagent.configuration-file)
+```
+
+Consequences:
+
+- A value in `otel.properties` acts as a **default**; both an env var and a `-D` flag will
+  override it. This is exactly why keeping `otel.exporter.otlp.endpoint=http://localhost:4318`
+  as a default in the file and **overriding it with `OTEL_EXPORTER_OTLP_ENDPOINT` in the
+  cluster** works cleanly.
+- The Dockerfile sets several `OTEL_*` as `ENV` defaults; those (env vars) will override the
+  same key in a config file. So decide where a given default lives to avoid confusion.
+- A stray `OTEL_*` env var in your shell can silently override the file — worth checking if a
+  value seems ignored.
+
+---
+
+## 4. How to supply the configuration
+
+Three approaches; they can be combined (defaults in a file, per-environment overrides via env).
+
+**A. Environment variables (recommended for the cluster).** Native mechanism for
+Docker/Kubernetes. The Dockerfile already carries `OTEL_*` defaults; the orchestrator
+overrides per environment.
+
+```bash
+OTEL_ENABLED=true \
+OTEL_SERVICE_NAME=wegas \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_METRICS_EXPORTER=otlp \
+OTEL_LOGS_EXPORTER=none \
+./run
+```
+
+**B. Agent config file (`otel.properties`), good for stable defaults.** Create a file using
+the **dotted** keys, and the `run` script passes it to the agent via
+`-Dotel.javaagent.configuration-file`. Then a run is simply `OTEL_ENABLED=true ./run`.
+
+```properties
+# otel.properties
+otel.service.name=wegas
+otel.exporter.otlp.endpoint=http://localhost:4318
+otel.exporter.otlp.protocol=http/protobuf
+otel.traces.exporter=otlp
+otel.metrics.exporter=otlp
+otel.logs.exporter=none
+```
+
+Because of precedence (§3), you can keep **one** committed `otel.properties` with stable
+defaults and override only the environment-specific bits (endpoint, `deployment.environment`,
+sampling) with env vars in the cluster — no need for separate prod/local files.
+
+**C. Hardcode `-Dotel.*` flags in `run`.** Works, but clutters the java command; use only
+for one or two values that never change.
+
+---
+
+## 5. Why `OTEL_ENABLED` is special (and why the agent needs it)
+
+`OTEL_ENABLED` is **not** an OpenTelemetry variable — it is our own switch inside
+[`wegas-runtime/run`](run):
+
+```bash
+OTEL_ENABLED="${OTEL_ENABLED:-false}"
+OTEL_OPTS=
+if [ "${OTEL_ENABLED}" = "true" ]; then
+    if [ -f "${OTEL_AGENT_JAR}" ]; then
+        OTEL_OPTS="-javaagent:${OTEL_AGENT_JAR}"
+        # ... optionally add -Dotel.javaagent.configuration-file=...
+    fi
+fi
+# later:
+"${JAVA_EXECUTABLE}" ${OTEL_OPTS} ... -jar ${PAYARA_MICRO} ...
+```
+
+The script uses it to decide **whether to add `-javaagent:` to the JVM at all**. This has two
+hard consequences:
+
+1. **It must be visible to the shell that runs `run`** — i.e. an exported environment
+   variable, an inline `OTEL_ENABLED=true ./run`, or the default baked into the script /
+   Dockerfile `ENV`. There is no other way for `run` to see it.
+2. **It cannot be file-driven** (not via `otel.properties`, not via the Wegas properties
+   files). A file read *by the agent* cannot decide whether the agent gets attached in the
+   first place — chicken and egg. And the Wegas properties files are loaded too late anyway
+   (§1a).
+
+**So: no `OTEL_ENABLED=true` in the environment → no
+`-javaagent` → the agent is never loaded, regardless of any `otel.*` config you set.**
+
+### Where to set it
+
+- **Locally:** `OTEL_ENABLED=true ./run`, or `export OTEL_ENABLED=true`.
+- **Cluster / Docker:** the Dockerfile default is `OTEL_ENABLED=false`; the orchestrator
+  (compose/k8s) sets it to `true` per environment.
+- **Change the default:** flip `:-false` to `:-true` in `run` if you want it on by default.
+
+### Alternative design
+
+You *could* drop the gate and **always** attach the agent, then use the agent-native
+`OTEL_SDK_DISABLED=true|false` (which *can* live in `otel.properties` or env) to turn
+telemetry on/off. The trade-off is that the agent is always loaded — you pay its
+startup/attach cost even when telemetry is off. Wegas uses the `OTEL_ENABLED` script gate
+specifically to avoid attaching the agent when it is not wanted.
+
+---
+
+## 6. Quick reference — local test against SigNoz
+
+```bash
+cd wegas-runtime
+
+# Sanity check the agent alone (prints spans to stdout, no backend needed):
+OTEL_ENABLED=true OTEL_TRACES_EXPORTER=logging OTEL_METRICS_EXPORTER=none OTEL_LOGS_EXPORTER=none ./run
+
+# Export traces to a locally-running SigNoz (OTLP on 4318):
+OTEL_ENABLED=true \
+OTEL_SERVICE_NAME=wegas \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+OTEL_TRACES_EXPORTER=otlp \
+OTEL_METRICS_EXPORTER=none \
+OTEL_LOGS_EXPORTER=none \
+./run
+```
+
+Then generate traffic and look in the SigNoz UI → **Services** for `wegas`.
+Enable metrics/logs later by flipping `OTEL_METRICS_EXPORTER` / `OTEL_LOGS_EXPORTER` to
+`otlp` — no rebuild required.

--- a/wegas-runtime/logging-example.properties
+++ b/wegas-runtime/logging-example.properties
@@ -1,0 +1,34 @@
+# Payara Micro Logging Properties Example File
+# Duplicate and remove '-example' from the filename.
+#
+# Purpose: quiet the very verbose server/boot logs (GlassFish, Hazelcast,
+# EclipseLink, Weld, JSF, ...) so the `run` banner and the Wegas application
+# logs stay readable.
+#
+# Note: this only affects Payara's java.util.logging (JUL) output. The Wegas
+# application logs via SLF4J/Logback (wegas-app/.../logback.xml) are NOT
+# governed by this file.
+
+## Handlers — keep the default console handler + Payara's ODL formatter (with colors)
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.formatter=com.sun.enterprise.server.logging.ODLLogFormatter
+com.sun.enterprise.server.logging.ODLLogFormatter.ansiColor=true
+java.util.logging.ConsoleHandler.level=INFO
+
+## Global level — only WARNING and above by default (this is what removes the bulk of the noise)
+.level=WARNING
+
+## Keep the Payara Micro "ready" banner: instance URLs / bound HTTP & SSL ports.
+## Important with --autobindhttp/--autobindssl, otherwise you won't see which port was chosen.
+PayaraMicro.level=INFO
+
+## Explicitly silence known-chatty sources (redundant with the global WARNING, kept for clarity)
+com.hazelcast.level=WARNING
+org.eclipse.persistence.level=WARNING
+org.jboss.weld.level=WARNING
+jakarta.enterprise.system.tools.deployment.level=WARNING
+
+## Suppress "NCLS-SECURITY-05054: certificate has expired" warnings for expired CA entries
+## in Payara's bundled truststore (cacerts.jks). Harmless boot noise; SEVERE keeps real SSL errors.
+## NB: the logger name is "javax.*" (not "jakarta.*") even on Payara 6.
+javax.enterprise.system.security.ssl.level=SEVERE

--- a/wegas-runtime/otel.properties
+++ b/wegas-runtime/otel.properties
@@ -1,0 +1,8 @@
+# Default values, override with equivalent ENV var.
+# !!!-- Update with precaution --!!!
+otel.service.name=wegas
+otel.exporter.otlp.endpoint=http://localhost:4318
+otel.exporter.otlp.protocol=http/protobuf
+otel.traces.exporter=otlp
+otel.metrics.exporter=otlp
+otel.logs.exporter=none

--- a/wegas-runtime/pom.xml
+++ b/wegas-runtime/pom.xml
@@ -161,25 +161,31 @@
                   <configuration>
                     <outputDirectory>${basedir}/src/main/docker/wegas</outputDirectory>
                     <resources>
-                      <resource>
-                        <directory>${basedir}</directory>
-                        <includes>
-                          <include>run</include>
-                          <include>as_prebootcmd</include>
-                        </includes>
-                    </resource>
-                      <resource>
-                          <directory>${basedir}/target</directory>
-                        <includes>
-                          <include>payara-micro.current.jar</include>
-                        </includes>
-                      </resource>
-                      <resource>
-                          <directory>${basedir}/../wegas-app/target</directory>
-                        <includes>
-                          <include>Wegas.war</include>
-                        </includes>
-                      </resource>
+                        <resource>
+                            <directory>${basedir}</directory>
+                            <includes>
+                                <include>run</include>
+                                <include>as_prebootcmd</include>
+                            </includes>
+                        </resource>
+                        <resource>
+                            <directory>${basedir}/target</directory>
+                            <includes>
+                                <include>payara-micro.current.jar</include>
+                            </includes>
+                        </resource>
+                        <resource>
+                            <directory>${basedir}/../wegas-app/target</directory>
+                            <includes>
+                                <include>Wegas.war</include>
+                            </includes>
+                        </resource>
+                        <resource>
+                            <directory>${basedir}/target</directory>
+                            <includes>
+                                <include>opentelemetry-javaagent.jar</include>
+                            </includes>
+                        </resource>
                     </resources>
                   </configuration>
                 </execution>
@@ -233,6 +239,14 @@
                                     <version>${payara.micro.version}</version>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.basedir}/target/</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${otel.agent.version}</version>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.basedir}/target/</outputDirectory>
+                                    <destFileName>opentelemetry-javaagent.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/wegas-runtime/run
+++ b/wegas-runtime/run
@@ -81,6 +81,11 @@ else
     OTEL_STATUS="ON — agent=${OTEL_AGENT_JAR}, endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:-<default http://localhost:4318 or otel.properties>}${OTEL_CONFIG_INFO}"
 fi
 
+# Payara Micro server-log verbosity based on a properties file (if present)
+LOG_PROPERTIES="${LOG_PROPERTIES:-logging.properties}"
+LOG_PROPERTIES_OPTION=
+[ -f "${LOG_PROPERTIES}" ] && LOG_PROPERTIES_OPTION="--logproperties ${LOG_PROPERTIES}"
+
 function show_help {
     echo "Usage: ./run [OPTIONS]"
     echo " -c CLUSTER_MODE datagrid discovery mode (default is ${CLUSTER_MODE})"
@@ -270,6 +275,7 @@ fi
     -jar ${PAYARA_MICRO} \
     --deploy ${THE_WAR} \
     --prebootcommandfile as_prebootcmd \
+    ${LOG_PROPERTIES_OPTION} \
     ${CLUSTERMODE_OPT} \
     --clusterName ${HZ_CLUSTER_NAME} \
     --minhttpthreads ${NB_THREADS} --maxhttpthreads ${NB_THREADS} \

--- a/wegas-runtime/run
+++ b/wegas-runtime/run
@@ -59,6 +59,28 @@ DEFAULT_WEGAS_PROPERTIES_ORI=./src/main/resources/default_wegas.properties.orig
 
 GC=${GC:-G1GC}
 
+# OpenTelemetry Java agent (opt-in)
+OTEL_ENABLED="${OTEL_ENABLED:-false}"
+OTEL_AGENT_JAR="${OTEL_AGENT_JAR:-target/opentelemetry-javaagent.jar}"
+OTEL_CONFIG_FILE="${OTEL_CONFIG_FILE:-otel.properties}"
+
+# Build the -javaagent option (if enabled).
+# OTEL_STATUS is purely informational.
+OTEL_OPTS=
+if [ "${OTEL_ENABLED}" != "true" ]; then
+    OTEL_STATUS="OFF (set OTEL_ENABLED=true to attach the agent)"
+elif [ ! -f "${OTEL_AGENT_JAR}" ]; then
+    OTEL_STATUS="ENABLED but jar NOT FOUND at ${OTEL_AGENT_JAR} — agent NOT attached"
+else
+    OTEL_OPTS="-javaagent:${OTEL_AGENT_JAR}"
+    OTEL_CONFIG_INFO=""
+    if [ -f "${OTEL_CONFIG_FILE}" ]; then
+        OTEL_OPTS="${OTEL_OPTS} -Dotel.javaagent.configuration-file=${OTEL_CONFIG_FILE}"
+        OTEL_CONFIG_INFO=", config=${OTEL_CONFIG_FILE}"
+    fi
+    OTEL_STATUS="ON — agent=${OTEL_AGENT_JAR}, endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:-<default http://localhost:4318 or otel.properties>}${OTEL_CONFIG_INFO}"
+fi
+
 function show_help {
     echo "Usage: ./run [OPTIONS]"
     echo " -c CLUSTER_MODE datagrid discovery mode (default is ${CLUSTER_MODE})"
@@ -114,9 +136,9 @@ if [ "${CLUSTER_MODE}" = "DEFAULT" ]; then
       # macOs: multicast does not work...
       CLUSTERMODE_OPT="--clustermode tcpip:127.0.0.1:6900";
     fi
-else                        
+else
     CLUSTERMODE_OPT="--clustermode ${CLUSTER_MODE}";
-fi  
+fi
 
 DEBUG_OPTS=
 if [ "${DEBUG}" == "true" ]; then
@@ -194,6 +216,7 @@ echo " * DB_HOST:    ${DB_HOST}"
 echo " * DB_PORT:    ${DB_PORT}"
 echo " * MONGO_HOST: ${MONGO_HOST}"
 echo " * JAVA:       $($JAVA_EXECUTABLE --version)"
+echo " * OTel:       ${OTEL_STATUS}"
 [ -n "${DEBUG_OPTS}" ] && echo " * Debug:      ${DEBUG_OPTS}"
 echo ----------
 
@@ -226,7 +249,7 @@ if [ ! -z "${WEGAS_PROPERTIES}" ] && [ ! -f "${WEGAS_PROPERTIES}" ]; then
     WEGAS_PROPERTIES_OPTION=
 fi
 
-"${JAVA_EXECUTABLE}" ${DEBUG_OPTS} ${JAVA_EXTRA_OPTS} ${GC_OPT} ${HTTP2_OPTS} \
+"${JAVA_EXECUTABLE}" ${OTEL_OPTS} ${DEBUG_OPTS} ${JAVA_EXTRA_OPTS} ${GC_OPT} ${HTTP2_OPTS} \
     -XX:+UnlockDiagnosticVMOptions \
     -Dproduct.name= -XX:+ParallelRefProcEnabled -XX:+UseCompressedOops -XX:-UseLoopPredicate \
     -Xms${HEAP} -Xmx${HEAP} \

--- a/wegas-runtime/src/main/docker/wegas/Dockerfile
+++ b/wegas-runtime/src/main/docker/wegas/Dockerfile
@@ -40,6 +40,17 @@ ENV SSL_PORT=443
 ENV WEGAS_PROPERTIES=/var/lib/wegas/wegas.properties
 ENV PATCH_WEGAS_PROPERTIES=false
 
+# OpenTelemetry (opt-in; see OTEL.md). Disabled by default so the image is inert until an
+# operator enables it and points it at a collector.
+ENV OTEL_ENABLED=false
+ENV OTEL_AGENT_JAR=${WORKDIR}/opentelemetry-javaagent.jar
+ENV OTEL_SERVICE_NAME=wegas
+
+# ENV OTEL_EXPORTER_OTLP_ENDPOINT unset to fail loudly if missing in ENV variables
+ENV OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+ENV OTEL_TRACES_EXPORTER=otlp
+ENV OTEL_METRICS_EXPORTER=otlp
+ENV OTEL_LOGS_EXPORTER=none
 
 # Create image
 
@@ -60,6 +71,7 @@ VOLUME /var/lib/wegas/
 COPY as_prebootcmd .
 COPY run .
 COPY payara-micro.current.jar payara-micro.jar
+COPY opentelemetry-javaagent.jar opentelemetry-javaagent.jar
 COPY Wegas.war ROOT.war
 
 RUN chown -R payara:payara .


### PR DESCRIPTION
- Added `OTEL_ENABLED` flag in `run` script that'll inject the pentelemetry-javaagent` if true.
- Added default config file `otel.properties` -> Can be overridden by ENV vars.
- Added `OTEL.md` for explanations.
- Added a `logging.properties` file condition in `run`
  - If the file exists, it'll apply it
  - Otherwise it is ignored
- Added a `logging-example.properties` that can be duplicated and used to silence lousy logs.